### PR TITLE
Allow using custom model options

### DIFF
--- a/src/Chat/ChatInterface.php
+++ b/src/Chat/ChatInterface.php
@@ -30,4 +30,6 @@ interface ChatInterface
     public function setFunctions(array $functions): void;
 
     public function addFunction(FunctionInfo $functionInfo): void;
+
+    public function setModelOption(string $option, mixed $value): void;
 }

--- a/src/OpenAIConfig.php
+++ b/src/OpenAIConfig.php
@@ -13,4 +13,24 @@ class OpenAIConfig
     public ?Client $client = null;
 
     public string $model;
+
+    /**
+     * model options, example:
+     * - temperature
+     * - max_tokens
+     * - presence_penalty
+     * - frequency_penalty
+     * - n
+     * - logprobs
+     * - top_logprobs
+     * - stop
+     * - user
+     * - top_p
+     * - response_format
+     *
+     * @see https://platform.openai.com/docs/api-reference/chat/create
+     *
+     * @var array<string, mixed>
+     */
+    public ?array $modelOptions = [];
 }


### PR DESCRIPTION
Hi,

This PR to allow the use of custom values for model options, like those one below :

- temperature
- max_tokens
- presence_penalty
- frequency_penalty
- n
- logprobs
- top_logprobs
- stop
- user
- top_p
- response_format

I used a simple assoc array, instead of defining each options in the OpenAIConfig object for 2 reasons:

- 1 simplicity
- 2 versatility. Since OpenAIConfig object is shared with both OpenAIChat and MistralAIChat, and even if the options should be the same, we can't know for sure they won't diverge. It allow us to simply put some keys that will be transfered to the LLM API.

What do you think ?